### PR TITLE
Enhance SecretTag UI with button-based toggle

### DIFF
--- a/mininterface/textual_interface/textual_adaptor.py
+++ b/mininterface/textual_interface/textual_adaptor.py
@@ -1,25 +1,20 @@
 from typing import TYPE_CHECKING
 
-from textual import events
-from textual.app import App, ComposeResult
-from textual.binding import Binding
-from textual.containers import VerticalScroll
 from textual.widget import Widget
 from textual.widgets import Rule, Label, RadioButton
 
 from .textual_facet import TextualFacet
 from .file_picker_input import FilePickerInput
 
-from ..auxiliary import flatten
 from ..exceptions import Cancelled
 from ..experimental import SubmitButton
 from ..facet import BackendAdaptor
-from ..form_dict import TagDict, formdict_to_widgetdict
+from ..form_dict import TagDict
 from ..tag import Tag
-from ..types import DatetimeTag, PathTag, SecretTag
-from .textual_app import TextualApp, WidgetList
+from ..types import PathTag, SecretTag
+from .textual_app import TextualApp
 from .widgets import (Changeable, MyButton, MyCheckbox, MyInput, MyRadioSet,
-                      MySubmitButton, SecretInput)
+                      MySubmitButton, MySecretInput)
 
 if TYPE_CHECKING:
     from . import TextualInterface
@@ -49,7 +44,7 @@ class TextualAdaptor(BackendAdaptor):
                 case PathTag():
                     o = FilePickerInput(tag, placeholder=tag.name or "")
                 case SecretTag():
-                    o = SecretInput(tag, placeholder=tag.name or "", type="text")
+                    o = MySecretInput(tag, placeholder=tag.name or "", type="text")
         # Special type: Submit button
         elif tag.annotation is SubmitButton:  # NOTE EXPERIMENTAL
             o = MySubmitButton(tag.name)

--- a/mininterface/textual_interface/textual_app.py
+++ b/mininterface/textual_interface/textual_app.py
@@ -136,13 +136,7 @@ class MainContents(Static):
         self.focusable_.extend(w for w in self.widgets if isinstance(w, (Input, Changeable)))
 
     def on_mount(self):
-        if self.widgets and 0 <= self.focused_i < len(self.widgets):
-            widget = self.widgets[self.focused_i]
-            # If it's a widget with an input field (like FilePickerInput), focus that input
-            if hasattr(widget, "input") and hasattr(widget.input, "focus"):
-                widget.input.focus()
-            else:
-                widget.focus()
+        self.widgets[self.focused_i].focus()
 
     def on_key(self, event: events.Key) -> None:
         f = self.focusable_

--- a/mininterface/textual_interface/textual_app.py
+++ b/mininterface/textual_interface/textual_app.py
@@ -124,12 +124,12 @@ class MainContents(Static):
                     yield Label(fieldt.placeholder)
                 # TODO MyRadioSet not shown now: add name in widgetize and display here
                 # NOTE: has this something to do with the PathTag?
-                elif hasattr(fieldt, "_link") and fieldt._link.name and not isinstance(fieldt, Input):
-                    yield Label(fieldt._link.name)
+                elif hasattr(fieldt, "tag") and fieldt.tag.name and not isinstance(fieldt, Input):
+                    yield Label(fieldt.tag.name)
                 yield fieldt
                 if isinstance(fieldt, Changeable) and (arb := fieldt._arbitrary):
                     yield arb
-                if isinstance(fieldt, Changeable) and (desc := fieldt._link.description):
+                if isinstance(fieldt, Changeable) and (desc := fieldt.tag.description):
                     yield Label(desc)
                 yield Label("")
         self.focusable_.clear()
@@ -162,7 +162,7 @@ class MainContents(Static):
                         case Checkbox():
                             label = inp_.label
                         case Changeable():
-                            label = inp_._link.name
+                            label = inp_.tag.name
                         case _:
                             label = ""
                     if str(label).casefold().startswith(letter):


### PR DESCRIPTION
- Create MySecretInput class using horizontal layout for better UI
- Add Show/Hide toggle button on the right side similar to PathTag's Browse button
- Implement keyboard shortcut (Ctrl+T) for toggling password visibility
- Maintain consistent styling with other form elements
- Improve user experience for password input fields
- Removed unused imports
<img width="952" alt="Screenshot 2025-03-27 at 18 17 12" src="https://github.com/user-attachments/assets/02530d24-29ff-4210-994f-48906d323df9" />
