### PR TITLE
Fix/tui pathtag multiple

### DIFF
--- a/mininterface/textual_interface/file_picker_input.py
+++ b/mininterface/textual_interface/file_picker_input.py
@@ -172,12 +172,16 @@ class FileBrowser(Vertical):
                 try:
                     if item.is_dir():
                         branch = node.add(f"📁 {item.name}", data=item, expand=False)
-                        if next(item.iterdir(), None) is not None:
-                            branch.add("Loading...")
+                        try:
+                            if next(item.iterdir(), None) is not None:
+                                branch.add("Loading...")
+                        except (PermissionError, OSError):
+                            pass
                     else:
                         if not self.tag.is_dir:
-                            node.add(f"📄 {item.name}", data=item)
-                except PermissionError:
+                            # Add file nodes as non-expandable
+                            node.add(f"📄 {item.name}", data=item, expand=False).allow_expand = False
+                except (PermissionError, OSError):
                     continue
 
         except PermissionError:

--- a/mininterface/textual_interface/file_picker_input.py
+++ b/mininterface/textual_interface/file_picker_input.py
@@ -431,6 +431,9 @@ def FilePickerInputFactory(adaptor: "TextualAdaptor", tag: PathTag, **kwargs):
             """Focus the tree widget after it's mounted."""
             if self.browser and self.browser._tree:
                 self.browser._tree.focus()
+                # Select the first node if it exists
+                if self.browser._tree.root.children:
+                    self.browser._tree.select_node(self.browser._tree.root.children[0])
 
         def get_ui_value(self):
             """Get the current value of the input field."""


### PR DESCRIPTION
Related with issue #23 

✅ Fixed Issues:

1. Enter Key Behavior
   - Fixed the issue where hitting Enter twice toggles the button but nothing happens
   - Now requires only two Enter presses to select and close the picker
   - Third Enter press is no longer needed

2. Multiple Mode Directory Selection
   - Fixed the issue where directories couldn't be selected with Enter in multiple mode
   - Now properly handles directory selection in multiple mode

3. Error Message Display
   - Fixed the misleading "Error, not a directory" message when selecting files in multiple mode
   - Now correctly indicates file selection without error messages

4. Node Persistence
   - Fixed the issue where previous nodes disappear when reopening the picker
   - Now maintains the selection history when reopening the picker

5. Navigation Improvements
   - I think it's a more intuitive approach to see the parent when navigating to inner directories since when you return with escape, there is already a plain view.
