### PR TITLE
Fix/combobox enter (issue#41)

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -55,6 +55,7 @@
 * enh: Tk better file dialog
 * feat: [Tag.mnemonic][mininterface.Tag.mnemonic]
 * feat: config file tuple annotation support
+* fix (GUI): combobox Enter key submits form after selection
 
 ## 1.0.2 (2025-05-10)
 * fix: mute TextInterface on Win

--- a/mininterface/_tk_interface/secret_entry.py
+++ b/mininterface/_tk_interface/secret_entry.py
@@ -25,6 +25,7 @@ class SecretEntryWrapper:
         """Handle toggle key event"""
         self.toggle_show()
         return "break"  # Prevent event propagation
+    
 
     def toggle_show(self):
         if self.tag.toggle_visibility():

--- a/mininterface/_tk_interface/select_input.py
+++ b/mininterface/_tk_interface/select_input.py
@@ -193,7 +193,8 @@ class SelectInputWrapper:
         widget = AutoCombobox(self.frame, textvariable=self.variable)
         widget["values"] = [k for k, *_ in options]
         widget.pack()
-        widget.bind("<Return>", lambda _: "break")  # override default enter that submits the form
+        #widget.bind("<Return>", lambda _: "break")  # override default enter that submits the form
+        widget.bind("<Return>", lambda _: self._enter_handler())
 
         self.set_default_label()
         self.taking_focus = widget
@@ -212,3 +213,13 @@ class SelectInputWrapper:
             # We never want to select the radiobutton in the initial phase
             # as this might trigger on_change action (not caused by the user)
             var.set(val)
+            
+    def _enter_handler(self, event=None):
+        current_value = self.variable.get()
+        
+        if not current_value:
+            return "break"  # Let it perform the default behavior and open the dropdown
+
+        # If it has a value, submit it
+        self.adaptor._ok()
+        return "break"


### PR DESCRIPTION
This PR adjusts the Enter key behavior for combobox inputs.

- First Enter opens the dropdown
- Once a value is selected, Enter submits the form

This addresses the behavior described in issue #41.

Note: It’s not entirely consistent that pressing Enter in foo1 submits the form while pressing Enter in foo2 does not. This behavior mirrors the current handling in the code, but could be revisited for consistency.